### PR TITLE
Support contacts in api

### DIFF
--- a/fake_ubersmith/api/adapters/data_store.py
+++ b/fake_ubersmith/api/adapters/data_store.py
@@ -18,6 +18,7 @@ class DataStore(object):
         self.credit_cards = []
         self.countries = {}
         self.clients = []
+        self.contacts = []
         self.coupons = []
         self.order = {}
         self.order_submit = {}

--- a/fake_ubersmith/api/methods/client.py
+++ b/fake_ubersmith/api/methods/client.py
@@ -51,9 +51,10 @@ class Client(Base):
         )
 
     def client_add(self, form_data):
-        client_id = len(self.data_store.clients)
+        client_id = len(self.data_store.clients) + 1
 
         form_data["clientid"] = client_id
+        form_data["contact_id"] = 0
         self.data_store.clients.append(form_data)
 
         return response(data=str(client_id))
@@ -74,6 +75,14 @@ class Client(Base):
                 error_code=1,
                 message="Client ID '{}' not found.".format(client_id)
             )
+
+    def contact_add(self, form_data):
+        contact_id = len(self.data_store.contacts) + 1
+        form_data["contact_id"] = contact_id
+
+        self.data_store.contacts.append(form_data)
+
+        return response(data=str(contact_id))
 
     @record(method='client.cc_add')
     def client_cc_add(self, form_data):

--- a/tests/methods/test_client.py
+++ b/tests/methods/test_client.py
@@ -27,7 +27,7 @@ class TestClientModule(unittest.TestCase):
 
     @patch('fake_ubersmith.api.methods.client.response')
     def test_client_add_creates_a_client(self, m_resp):
-        m_resp.return_value = '{"data": "0", ' \
+        m_resp.return_value = '{"data": "1", ' \
                               '"error_code": null, ' \
                               '"error_message": "", ' \
                               '"status": true}'
@@ -45,7 +45,7 @@ class TestClientModule(unittest.TestCase):
             m_resp.return_value
         )
 
-        m_resp.assert_called_once_with(data="0")
+        m_resp.assert_called_once_with(data="1")
 
     @patch('fake_ubersmith.api.methods.client.response')
     def test_client_get_returns_successfully(self, m_resp):
@@ -81,6 +81,28 @@ class TestClientModule(unittest.TestCase):
         m_resp.assert_called_once_with(
            error_code=1, message="Client ID '1' not found."
         )
+
+    @patch('fake_ubersmith.api.methods.client.response')
+    def test_client_contact_add_creates_a_contact(self, m_resp):
+        m_resp.return_value = '{"data": "1", ' \
+                              '"error_code": null, ' \
+                              '"error_message": "", ' \
+                              '"status": true}'
+
+        self.assertEqual(
+            self.client.contact_add(
+                form_data={
+                    'client_id': 1,
+                    'real_name': 'John Doe',
+                    'email': 'john.doe@invalid.com',
+                    'login': 'john',
+                    'password': 'doe',
+                }
+            ),
+            m_resp.return_value
+        )
+
+        m_resp.assert_called_once_with(data="1")
 
     @patch('fake_ubersmith.api.methods.client.response')
     def test_client_cc_add_is_successful(self, m_resp):

--- a/tests/methods/test_uber.py
+++ b/tests/methods/test_uber.py
@@ -121,10 +121,11 @@ class TestUberModule(unittest.TestCase):
         )
 
     @patch('fake_ubersmith.api.methods.uber.response')
-    def test_check_login_succesfully(self, m_resp):
+    def test_check_login_succesfully_for_client(self, m_resp):
         self.data_store.clients = [
             {
-                'clientid': '0',
+                'clientid': '1',
+                'contact_id': '0',
                 'first': 'John',
                 'last': 'Smith',
                 'email': 'john.smith@invalid.com',
@@ -133,7 +134,7 @@ class TestUberModule(unittest.TestCase):
             }
         ]
 
-        m_resp.return_value = '{"data": {"client_id": "0"}, ' \
+        m_resp.return_value = '{"data": {"client_id": "1", "contact_id": "0"}, ' \
                               '"error_code": null, ' \
                               '"error_message": "", ' \
                               '"status": true' \
@@ -143,19 +144,19 @@ class TestUberModule(unittest.TestCase):
             self.uber.check_login(
                 form_data={"login": "john", "pass": "smith"}
             ),
-            '{"data": {"client_id": "0"}, '
+            '{"data": {"client_id": "1", "contact_id": "0"}, '
             '"error_code": null, "error_message": "", "status": true}'
         )
 
         m_resp.assert_called_once_with(
-            data={"client_id": "0"}
+            data={"client_id": "1", "contact_id": "0"}
         )
 
     @patch('fake_ubersmith.api.methods.uber.response')
     def test_check_login_failed(self, m_resp):
         self.data_store.clients = [
             {
-                'clientid': '0',
+                'clientid': '1',
                 'first': 'John',
                 'last': 'Smith',
                 'email': 'john.smith@invalid.com',
@@ -182,3 +183,34 @@ class TestUberModule(unittest.TestCase):
         )
 
         m_resp.assert_called_once_with(error_code=3, message="Invalid login or password.")
+
+    @patch('fake_ubersmith.api.methods.uber.response')
+    def test_check_login_sucessfully_for_contact(self, m_resp):
+        self.data_store.contacts = [
+            {
+                'client_id': '1234',
+                'contact_id': '1',
+                'real_name': 'Line Doe',
+                'email': 'line.doe@invalid.com',
+                'login': 'line',
+                'password': 'doe',
+            }
+        ]
+
+        m_resp.return_value = '{"data": {"client_id": "1234", "contact_id": "1"}, ' \
+                              '"error_code": null, ' \
+                              '"error_message": "", ' \
+                              '"status": true' \
+                              '}'
+
+        self.assertEqual(
+            self.uber.check_login(
+                form_data={"login": "line", "pass": "doe"}
+            ),
+            '{"data": {"client_id": "1234", "contact_id": "1"}, '
+            '"error_code": null, "error_message": "", "status": true}'
+        )
+
+        m_resp.assert_called_once_with(
+            data={"client_id": "1234", "contact_id": "1"}
+        )


### PR DESCRIPTION
- Can create contact through client.contact_add api call
- Contact id is now return on check_login api call
- Client id starts at 1 now because 0 is impossible in UB and in UB world
  0 means "not set" et "null"
- Contact id is set to 0 on client add and it means the contact is the
  client itself. Contact id is not 0 only when calling client.contact_add
  api call