### PR TITLE
Return client type in the payload when login

### DIFF
--- a/fake_ubersmith/api/methods/uber.py
+++ b/fake_ubersmith/api/methods/uber.py
@@ -38,7 +38,12 @@ class Uber(Base):
 
     def check_login(self, form_data):
         data = self._get_client(form_data['login'], form_data['pass'])
-        return response(data=data) if data else response(
+
+        if data:
+            data['type'] = 'client'
+            return response(data=data)
+
+        return response(
             error_code=3, message="Invalid login or password."
         )
 

--- a/tests/api/methods/test_uber.py
+++ b/tests/api/methods/test_uber.py
@@ -170,7 +170,7 @@ class TestUberModule(unittest.TestCase):
             json.loads(resp.data.decode('utf-8')),
             {
                 "data": {
-                    "client_id": "1", "contact_id": "0"
+                    "client_id": "1", "contact_id": "0", "type": "client"
                 },
                 "error_code": None,
                 "error_message": "", "status": True
@@ -236,7 +236,7 @@ class TestUberModule(unittest.TestCase):
         self.assertEqual(
             json.loads(resp.data.decode('utf-8')),
             {
-                "data": {"client_id": "1234", "contact_id": "1"},
+                "data": {"client_id": "1234", "contact_id": "1", "type": "client"},
                 "error_code": None,
                 "error_message": "",
                 "status": True


### PR DESCRIPTION
For now the property is hardcoded to type='client'
so that dependent system doesn't crash