### PR TITLE
Fix client.get api contract

### DIFF
--- a/fake_ubersmith/api/methods/client.py
+++ b/fake_ubersmith/api/methods/client.py
@@ -63,6 +63,11 @@ class Client(Base):
         client_data = form_data.copy()
         client_data["clientid"] = client_id
         client_data["contact_id"] = str(0)
+
+        if client_data.get("uber_login"):
+            client_data["login"] = client_data.get("uber_login")
+            del client_data["uber_login"]
+
         self.data_store.clients.append(client_data)
 
         return response(data=client_id)

--- a/tests/api/methods/test_client.py
+++ b/tests/api/methods/test_client.py
@@ -57,6 +57,7 @@ class TestClientModule(unittest.TestCase):
                 "status": True
             }
         )
+        self.assertEqual(self.data_store.clients[0]["login"], "john")
 
     def test_client_get_returns_successfully(self):
         self.data_store.clients = [{"clientid": "1"}]


### PR DESCRIPTION
The uber_login attribute is stored as login
in Ubersmith so need to be return as login
in the api data