### PR TITLE
Fix uber.check_login contract again

### DIFF
--- a/fake_ubersmith/api/methods/uber.py
+++ b/fake_ubersmith/api/methods/uber.py
@@ -84,7 +84,7 @@ class Uber(Base):
 
     def _get_client(self, username, password):
         def _build_payload(client_id, contact_id, login):
-            return {"client_id": client_id, "contact_id": int(contact_id), "login": login}
+            return {"client_id": client_id, "contact_id": contact_id, "login": login}
 
         def _get_contact():
             return next(
@@ -93,7 +93,7 @@ class Uber(Base):
             )
 
         return next(
-            (_build_payload(c['clientid'], c["contact_id"], c["login"]) for c in self.data_store.clients if
+            (_build_payload(c['clientid'], int(c["contact_id"]), c["login"]) for c in self.data_store.clients if
              c['login'] == username and c['uber_pass'] == password),
             _get_contact()
         )

--- a/tests/api/methods/test_uber.py
+++ b/tests/api/methods/test_uber.py
@@ -236,7 +236,7 @@ class TestUberModule(unittest.TestCase):
         self.assertEqual(
             json.loads(resp.data.decode('utf-8')),
             {
-                "data": {"client_id": "1234", "contact_id": 1, "type": "client", "login": "line"},
+                "data": {"client_id": "1234", "contact_id": "1", "type": "client", "login": "line"},
                 "error_code": None,
                 "error_message": "",
                 "status": True


### PR DESCRIPTION
When doing check_login on a client, the contact_id is returned as
a int but when doing check_login on a contact the contact id
different from 0 is returned as a string