### PR TITLE
Do not add a default e-mail if it is not set on a client

### DIFF
--- a/fake_ubersmith/api/methods/uber.py
+++ b/fake_ubersmith/api/methods/uber.py
@@ -98,7 +98,7 @@ class Uber(Base):
                 "contact_id": contact_id,
                 "login": login,
                 "fullname": full_name or "A Full Name",
-                "email": email or "stuff@invalid.invalid"
+                "email": email
             }
 
         def _get_contact():


### PR DESCRIPTION
This is a case that can happen in real UB so it is now handled
here so dependent systems can test against that case as well