### PR TITLE
Create the primary contact when client_add api is called

### DIFF
--- a/fake_ubersmith/api/methods/client.py
+++ b/fake_ubersmith/api/methods/client.py
@@ -76,6 +76,13 @@ class Client(Base):
         self.logger.info("Adding client data: {}".format(client_data))
 
         self.data_store.clients.append(client_data)
+        self.data_store.contacts.append(
+            dict(
+                contact_id=str(len(self.data_store.contacts) + 1),
+                client_id=client_id,
+                description="Primary Contact"
+            )
+        )
 
         return response(data=client_id)
 

--- a/tests/integration/test_ubersmith_client.py
+++ b/tests/integration/test_ubersmith_client.py
@@ -21,8 +21,10 @@ class TestUbersmithClient(Base):
         client_id = self.ub_client.client.add(uber_login='username')
 
         result = self.ub_client.client.get(client_id=client_id)
+        self.assertDictEqual(result, {'clientid': client_id, 'login': 'username'})
 
-        self.assertEqual(result, {'clientid': client_id, 'login': 'username'})
+        result = self.ub_client.client.contact_list(client_id=client_id)
+        self.assertDictEqual(result, {'1': {'contact_id': '1', 'description': 'Primary Contact', 'client_id': '1'}})
 
     def test_list_all_contacts_works(self):
         self.ub_client.client.contact_add(client_id='1234')
@@ -31,11 +33,11 @@ class TestUbersmithClient(Base):
 
         result = self.ub_client.client.contact_list(client_id='1234')
 
-        self.assertEqual(
+        self.assertDictEqual(
             result,
             {
-                '1': {'client_id': '1234', 'contact_id': '1'},
-                '2': {'client_id': '1234', 'contact_id': '2'}
+                '2': {'client_id': '1234', 'contact_id': '2'},
+                '3': {'client_id': '1234', 'contact_id': '3'}
             }
         )
 

--- a/tests/unit/api/methods/test_client.py
+++ b/tests/unit/api/methods/test_client.py
@@ -48,8 +48,9 @@ class TestClientModule(unittest.TestCase):
             )
 
         self.assertEqual(resp.status_code, 200)
+        body = json.loads(resp.data.decode('utf-8'))
         self.assertEqual(
-            json.loads(resp.data.decode('utf-8')),
+            body,
             {
                 "data": "1",
                 "error_code": None,
@@ -58,6 +59,9 @@ class TestClientModule(unittest.TestCase):
             }
         )
         self.assertEqual(self.data_store.clients[0]["login"], "john")
+        self.assertEqual(self.data_store.contacts[0]["contact_id"], "1")
+        self.assertEqual(self.data_store.contacts[0]["client_id"], body.get("data"))
+        self.assertEqual(self.data_store.contacts[0]["description"], "Primary Contact")
 
     def test_client_get_returns_successfully(self):
         with self.app.test_client() as c:


### PR DESCRIPTION
In Ubersmith, a primary contact representing the client is
created at the same time the client is created.