### PR TITLE
Add a username and password to the primary contact

### DIFF
--- a/fake_ubersmith/api/methods/client.py
+++ b/fake_ubersmith/api/methods/client.py
@@ -76,11 +76,12 @@ class Client(Base):
         self.logger.info("Adding client data: {}".format(client_data))
 
         self.data_store.clients.append(client_data)
-        self.data_store.contacts.append(
+        self.contact_add(
             dict(
-                contact_id=str(len(self.data_store.contacts) + 1),
                 client_id=client_id,
-                description="Primary Contact"
+                description="Primary Contact",
+                login="so_much_invalid_username",
+                password="so_much_invalid_password"
             )
         )
 

--- a/tests/integration/test_ubersmith_client.py
+++ b/tests/integration/test_ubersmith_client.py
@@ -24,7 +24,9 @@ class TestUbersmithClient(Base):
         self.assertDictEqual(result, {'clientid': client_id, 'login': 'username'})
 
         result = self.ub_client.client.contact_list(client_id=client_id)
-        self.assertDictEqual(result, {'1': {'contact_id': '1', 'description': 'Primary Contact', 'client_id': '1'}})
+
+        self.assertEqual(result.get('1').get("client_id"), client_id)
+        self.assertEqual(result.get('1').get("description"), 'Primary Contact')
 
     def test_list_all_contacts_works(self):
         self.ub_client.client.contact_add(client_id='1234')


### PR DESCRIPTION
The uber.check_login required those params to be able to check
the login of a user