### PR TITLE
Fixed iweb vendor module bootstrap

### DIFF
--- a/fake_ubersmith/api/methods/vendor_modules/iweb.py
+++ b/fake_ubersmith/api/methods/vendor_modules/iweb.py
@@ -15,7 +15,7 @@ from fake_ubersmith.api.base import Base
 from fake_ubersmith.api.utils.response import response
 
 
-class Iweb(Base):
+class IWeb(Base):
     def __init__(self, data_store):
         super().__init__(data_store)
 

--- a/fake_ubersmith/main.py
+++ b/fake_ubersmith/main.py
@@ -22,6 +22,7 @@ from fake_ubersmith.api.administrative_local import AdministrativeLocal
 from fake_ubersmith.api.methods.client import Client
 from fake_ubersmith.api.methods.order import Order
 from fake_ubersmith.api.methods.uber import Uber
+from fake_ubersmith.api.methods.vendor_modules.iweb import IWeb
 from fake_ubersmith.api.ubersmith import UbersmithBase
 
 
@@ -48,6 +49,7 @@ def run():
     Uber(data_store).hook_to(base_uber_api)
     Order(data_store).hook_to(base_uber_api)
     Client(data_store).hook_to(base_uber_api)
+    IWeb(data_store).hook_to(base_uber_api)
 
     base_uber_api.hook_to(app)
 

--- a/tests/integration/test_vendor_modules_iweb.py
+++ b/tests/integration/test_vendor_modules_iweb.py
@@ -1,0 +1,28 @@
+# Copyright 2017 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from tests.integration.base import Base
+
+
+class TestVendorModulesIWeb(Base):
+    def test_log_event(self):
+        result = self.ub_client.iweb.log_event(
+            event_type="ADMIN_CLIENT_EDITED",
+            reference_type="client",
+            action="A Message",
+            clientid="123456",
+            user="username",
+            reference_id="123456"
+        )
+
+        self.assertEqual(result, "1")

--- a/tests/unit/api/methods/vendor_modules/test_iweb.py
+++ b/tests/unit/api/methods/vendor_modules/test_iweb.py
@@ -17,7 +17,7 @@ import unittest
 from flask import Flask
 
 from fake_ubersmith.api.adapters.data_store import DataStore
-from fake_ubersmith.api.methods.vendor_modules.iweb import Iweb
+from fake_ubersmith.api.methods.vendor_modules.iweb import IWeb
 from fake_ubersmith.api.ubersmith import UbersmithBase
 
 
@@ -25,7 +25,7 @@ class TestIwebModule(unittest.TestCase):
 
     def setUp(self):
         self.data_store = DataStore()
-        self.iweb = Iweb(self.data_store)
+        self.iweb = IWeb(self.data_store)
 
         self.app = Flask(__name__)
         self.base_iweb_api = UbersmithBase(self.data_store)


### PR DESCRIPTION
The module is now loaded at the initialization of the application.

An integration test was added to prove that api call to iweb
vendor module is really working.