### PR TITLE
Support admin role management

### DIFF
--- a/fake_ubersmith/api/adapters/data_store.py
+++ b/fake_ubersmith/api/adapters/data_store.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections import defaultdict
 
 
 class DataStore:
@@ -26,3 +27,8 @@ class DataStore:
         self.service_plans = []
         self.service_plans_list = None
         self.event_log = []
+        self.roles = {}
+        self.user_mapping = defaultdict(lambda: defaultdict(set))
+
+    def flush(self):
+        self.__init__()

--- a/fake_ubersmith/api/methods/vendor_modules/iweb.py
+++ b/fake_ubersmith/api/methods/vendor_modules/iweb.py
@@ -11,8 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
+
+import collections
+
 from fake_ubersmith.api.base import Base
 from fake_ubersmith.api.utils.response import response
+from fake_ubersmith.api.utils.utils import a_random_id
 
 
 class IWeb(Base):
@@ -24,7 +29,55 @@ class IWeb(Base):
             ubersmith_method='iweb.log_event',
             function=self.log_event
         )
+        entity.register_endpoints(
+            ubersmith_method='iweb.acl_admin_role_add',
+            function=self.acl_admin_role_add
+        )
+        entity.register_endpoints(
+            ubersmith_method='iweb.user_role_assign',
+            function=self.user_role_assign
+        )
 
     def log_event(self, form_data):
         self.data_store.event_log.append(form_data.to_dict())
         return response(data="1")
+
+    def acl_admin_role_add(self, form_data):
+        if self._does_role_name_exist(form_data.get('name')):
+            return response(
+                error_code=1,
+                message="The specified Role Name is already in use"
+            )
+
+        role_id = str(a_random_id())
+        role_data = {}
+        acls = collections.defaultdict(dict)
+        for key, value in form_data.to_dict().items():
+            if 'acls' in key:
+                rule, level = list(filter(None, re.split(r"\[|\]", key)))[1:]
+                acls[rule][level] = value
+            else:
+                role_data[key] = value
+        role_data.update({'role_id': role_id, 'acls': acls})
+
+        self.data_store.roles[role_id] = role_data
+        return response(data=role_id)
+
+    def _does_role_name_exist(self, role_name):
+        return any(
+            role_name == data['name']
+            for _, data in self.data_store.roles.items()
+        )
+
+    def user_role_assign(self, form_data):
+        user_id = form_data.get('user_id')
+        role_id = str(form_data.get('role_id'))
+        roles = self.data_store.user_mapping.get(user_id, {}).get('roles', {})
+        if role_id in roles:
+            return response(
+                error_code=1,
+                message="Can't assign role with id '{}' "
+                        "to user with id '{}'".format(role_id, user_id)
+            )
+        self.data_store.user_mapping[user_id]['roles'].add(role_id)
+        return response(data=1)

--- a/tests/unit/api/methods/vendor_modules/test_iweb.py
+++ b/tests/unit/api/methods/vendor_modules/test_iweb.py
@@ -70,3 +70,134 @@ class TestIwebModule(unittest.TestCase):
             }
 
         )
+
+    def test_add_role_successfully(self):
+        with self.app.test_client() as c:
+            resp = c.post(
+                'api/2.0/',
+                data={
+                    "method": "iweb.acl_admin_role_add",
+                    'name': 'A Admin Role',
+                    'descr': 'A Admin Role',
+                    'acls[admin.portal][read]': 1,
+                }
+            )
+
+        role_id = next(iter(self.data_store.roles))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            json.loads(resp.data.decode('utf-8')),
+            {
+                "data": role_id,
+                "error_code": None,
+                "error_message": "",
+                "status": True
+            }
+        )
+        self.assertEqual(
+            self.data_store.roles,
+            {
+                role_id: {
+                    'role_id': role_id,
+                    'name': 'A Admin Role',
+                    'descr': 'A Admin Role',
+                    'acls': {
+                        'admin.portal': {'read': '1'}
+                    }
+                }
+            }
+        )
+
+    def test_add_role_that_already_exists_fails(self):
+        self.data_store.roles = {
+            'some_role_id': {
+                'role_id': 'some_role_id',
+                'name': 'A Admin Role'
+            }
+        }
+
+        with self.app.test_client() as c:
+            resp = c.post(
+                'api/2.0/',
+                data={
+                    "method": "iweb.acl_admin_role_add",
+                    'name': 'A Admin Role',
+                    'descr': 'A Admin Role',
+                    'acls[admin.portal][read]': 1,
+                }
+            )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            json.loads(resp.data.decode('utf-8')),
+            {
+                "data": "",
+                "error_code": 1,
+                "error_message": "The specified Role Name is already in use",
+                "status": False
+            }
+        )
+
+    def test_add_user_role_successfully(self):
+        user_id = 'some_user_id'
+        self.data_store.roles = {'a_role_id': {}, 'another_role_id': {}}
+        with self.app.test_client() as c:
+            c.post(
+                'api/2.0/',
+                data={
+                    "method": "iweb.user_role_assign",
+                    "user_id": user_id,
+                    "role_id": "a_role_id"
+                }
+            )
+            resp = c.post(
+                'api/2.0/',
+                data={
+                    "method": "iweb.user_role_assign",
+                    "user_id": user_id,
+                    "role_id": "another_role_id"
+                }
+            )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            json.loads(resp.data.decode('utf-8')),
+            {
+                "status": True,
+                "error_code": None,
+                "error_message": "",
+                "data": 1
+            }
+        )
+        self.assertEqual(
+            self.data_store.user_mapping[user_id],
+            {'roles': {'a_role_id', 'another_role_id'}}
+        )
+
+    def test_add_same_role_to_user_not_allowed(self):
+        role_id = 'some_role_id'
+        user_id = 'some_user_id'
+        self.data_store.roles = {'1': {}}
+        self.data_store.user_mapping[user_id] = {'roles': {role_id}}
+        with self.app.test_client() as c:
+            resp = c.post(
+                'api/2.0/',
+                data={
+                    "method": "iweb.user_role_assign",
+                    "user_id": user_id,
+                    "role_id": role_id
+                }
+            )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            json.loads(resp.data.decode('utf-8')),
+            {
+                "error_code": 1,
+                "error_message": "Can't assign role with id '{}' to user "
+                                 "with id '{}'".format(role_id, user_id),
+                "status": False,
+                "data": ""
+            }
+        )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,6 @@
+import random
+import string
+
+
+def a_random_string(length=8):
+    return ''.join(random.sample(string.ascii_lowercase, k=length))


### PR DESCRIPTION
This feature will provide support for the following API calls:
- iweb.acl_admin_role_add: Adds ability to add new roles with
  permissions
- uber.acl_admin_role_get: Get a particular role with its properties or
  role(s) assigned to a user
- iweb.user_assign_role: Assign a given role to a given user